### PR TITLE
feat: add support and tests for multiple validators in custom annotations

### DIFF
--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotations.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotations.java
@@ -95,7 +95,6 @@ public final class CustomAnnotations {
 					false);
 			mv.visitInsn(ATHROW);
 			mv.visitLabel(label0);
-			mv.visitFrame(F_APPEND, 1, new Object[] { validatorType }, 0, null);
 		}
 	}
 

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/MultipleValidatorsTest.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/MultipleValidatorsTest.java
@@ -1,0 +1,38 @@
+package com.github.pfichtner.vaadoo;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.MultipleValidatorsExample;
+
+class MultipleValidatorsTest {
+
+	private final Transformer transformer = new Transformer();
+
+	@Test
+	void bothValidatorsMustPass() throws Exception {
+		var transformed = transformer.transform(MultipleValidatorsExample.class);
+		var constructor = transformed.getDeclaredConstructor(String.class);
+
+		// Passes both: length >= 5 and starts with "A"
+		assertThatNoException().isThrownBy(() -> constructor.newInstance("ABCDE"));
+
+		// Fails Validator1 (length < 5)
+		assertThatThrownBy(() -> constructor.newInstance("ABCD"))
+				.hasCauseInstanceOf(IllegalArgumentException.class)
+				.hasRootCauseMessage("value MultipleValidators failed");
+
+		// Fails Validator2 (does not start with "A")
+		assertThatThrownBy(() -> constructor.newInstance("BCDEF"))
+				.hasCauseInstanceOf(IllegalArgumentException.class)
+				.hasRootCauseMessage("value MultipleValidators failed");
+                
+		// Fails both
+		assertThatThrownBy(() -> constructor.newInstance("BCDE"))
+				.hasCauseInstanceOf(IllegalArgumentException.class)
+				.hasRootCauseMessage("value MultipleValidators failed");
+	}
+
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MultipleValidators.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MultipleValidators.java
@@ -1,0 +1,13 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import jakarta.validation.Constraint;
+
+@Retention(RUNTIME)
+@Constraint(validatedBy = { Validator1.class, Validator2.class })
+public @interface MultipleValidators {
+	String message() default "{@@@NAME@@@} MultipleValidators failed";
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MultipleValidatorsExample.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MultipleValidatorsExample.java
@@ -1,0 +1,16 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import org.jmolecules.ddd.annotation.ValueObject;
+
+@ValueObject
+public class MultipleValidatorsExample {
+	private final String value;
+
+	public MultipleValidatorsExample(@MultipleValidators String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/Validator1.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/Validator1.java
@@ -1,0 +1,11 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class Validator1 implements ConstraintValidator<MultipleValidators, String> {
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		return value != null && value.length() >= 5;
+	}
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/Validator2.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/Validator2.java
@@ -1,0 +1,11 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class Validator2 implements ConstraintValidator<MultipleValidators, String> {
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		return value != null && value.startsWith("A");
+	}
+}


### PR DESCRIPTION
This PR verifies and ensures robust support for multiple validators within custom @Constraint annotations.

Changes
- Testing: Introduced MultipleValidatorsTest along with supporting test classes (MultipleValidators, Validator1, Validator2, and
    MultipleValidatorsExample) to explicitly test scenarios where a single annotation is validated by multiple ConstraintValidator implementations.
- Bug Fix: Removed an incorrect visitFrame call in CustomAnnotations.java. The call was incorrectly attempting to append a local variable that wasn't
    stored, and is redundant since the project uses COMPUTE_FRAMES.
- Validation: Verified that the {@@@NAME@@@} placeholder is correctly resolved in custom error messages when using multiple validators.

closes #85 
