### PR TITLE
Support for ConstraintValidator#initialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/
 *.iws
 .flattened-pom.xml
 changelog.txt
+.jqwik-database

--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotationValidatorClassVisitor.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotationValidatorClassVisitor.java
@@ -1,0 +1,191 @@
+package com.github.pfichtner.vaadoo;
+
+import static net.bytebuddy.jar.asm.Opcodes.ACC_FINAL;
+import static net.bytebuddy.jar.asm.Opcodes.ACC_PRIVATE;
+import static net.bytebuddy.jar.asm.Opcodes.ACC_PUBLIC;
+import static net.bytebuddy.jar.asm.Opcodes.ACC_STATIC;
+import static net.bytebuddy.jar.asm.Opcodes.ACC_SYNTHETIC;
+import static net.bytebuddy.jar.asm.Opcodes.ACONST_NULL;
+import static net.bytebuddy.jar.asm.Opcodes.ALOAD;
+import static net.bytebuddy.jar.asm.Opcodes.ARETURN;
+import static net.bytebuddy.jar.asm.Opcodes.ASM9;
+import static net.bytebuddy.jar.asm.Opcodes.ASTORE;
+import static net.bytebuddy.jar.asm.Opcodes.DUP;
+import static net.bytebuddy.jar.asm.Opcodes.H_INVOKESTATIC;
+import static net.bytebuddy.jar.asm.Opcodes.IFEQ;
+import static net.bytebuddy.jar.asm.Opcodes.INVOKESPECIAL;
+import static net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC;
+import static net.bytebuddy.jar.asm.Opcodes.INVOKEVIRTUAL;
+import static net.bytebuddy.jar.asm.Opcodes.NEW;
+import static net.bytebuddy.jar.asm.Opcodes.PUTSTATIC;
+import static net.bytebuddy.jar.asm.Opcodes.RETURN;
+
+import java.util.Collection;
+import java.util.Map;
+
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.Handle;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Type;
+
+public class CustomAnnotationValidatorClassVisitor extends ClassVisitor {
+
+	private final Collection<CustomValidatorInfo> validators;
+	private String owner;
+
+	public CustomAnnotationValidatorClassVisitor(ClassVisitor cv, Collection<CustomValidatorInfo> validators) {
+		super(ASM9, cv);
+		this.validators = validators;
+	}
+
+	private boolean clinitFound;
+
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		this.owner = name;
+		super.visit(version, access, name, signature, superName, interfaces);
+		for (CustomValidatorInfo info : validators) {
+			cv.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL | ACC_SYNTHETIC, info.getFieldName(),
+					"L" + info.getValidatorClass().getInternalName() + ";", null, null).visitEnd();
+			addHandlerMethod(info);
+		}
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+		if ("<clinit>".equals(name)) {
+			clinitFound = true;
+			MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+			return new MethodVisitor(ASM9, mv) {
+				@Override
+				public void visitInsn(int opcode) {
+					if (opcode == RETURN) {
+						initializeValidators(this);
+					}
+					super.visitInsn(opcode);
+				}
+			};
+		}
+		return super.visitMethod(access, name, desc, signature, exceptions);
+	}
+
+	@Override
+	public void visitEnd() {
+		if (!clinitFound && !validators.isEmpty()) {
+			MethodVisitor mv = cv.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+			mv.visitCode();
+			initializeValidators(mv);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 0);
+			mv.visitEnd();
+		}
+		super.visitEnd();
+	}
+
+	private void addHandlerMethod(CustomValidatorInfo info) {
+		String methodName = info.getFieldName() + "$handler";
+		MethodVisitor mv = cv.visitMethod(ACC_PRIVATE | ACC_STATIC | ACC_SYNTHETIC, methodName,
+				"(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ALOAD, 1); // Method
+		mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/reflect/Method", "getName", "()Ljava/lang/String;", false);
+		mv.visitVarInsn(ASTORE, 3); // name
+
+		for (Map.Entry<String, Object> entry : info.getAnnotationValues().entrySet()) {
+			mv.visitVarInsn(ALOAD, 3);
+			mv.visitLdcInsn(entry.getKey());
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
+			Label next = new Label();
+			mv.visitJumpInsn(IFEQ, next);
+
+			injectValue(mv, entry.getValue());
+			mv.visitInsn(ARETURN);
+			mv.visitLabel(next);
+		}
+
+		mv.visitInsn(ACONST_NULL);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(0, 0);
+		mv.visitEnd();
+	}
+
+	private void injectValue(MethodVisitor mv, Object value) {
+		if (value instanceof String) {
+			mv.visitLdcInsn(value);
+		} else if (value instanceof Integer) {
+			mv.visitLdcInsn(value);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;", false);
+		} else if (value instanceof Boolean) {
+			mv.visitLdcInsn(((Boolean) value) ? 1 : 0);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/Boolean", "valueOf", "(Z)Ljava/lang/Boolean;", false);
+		} else if (value instanceof Long) {
+			mv.visitLdcInsn(value);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/Long", "valueOf", "(J)Ljava/lang/Long;", false);
+		} else if (value instanceof Double) {
+			mv.visitLdcInsn(value);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", "valueOf", "(D)Ljava/lang/Double;", false);
+		} else if (value instanceof Float) {
+			mv.visitLdcInsn(value);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/Float", "valueOf", "(F)Ljava/lang/Float;", false);
+		} else if (value instanceof net.bytebuddy.description.enumeration.EnumerationDescription) {
+			net.bytebuddy.description.enumeration.EnumerationDescription enumValue = (net.bytebuddy.description.enumeration.EnumerationDescription) value;
+			mv.visitFieldInsn(net.bytebuddy.jar.asm.Opcodes.GETSTATIC, enumValue.getEnumerationType().getInternalName(),
+					enumValue.getValue(), enumValue.getEnumerationType().getDescriptor());
+		} else if (value instanceof net.bytebuddy.description.type.TypeDescription) {
+			mv.visitLdcInsn(
+					Type.getObjectType(((net.bytebuddy.description.type.TypeDescription) value).getInternalName()));
+		} else if (value == null) {
+			mv.visitInsn(ACONST_NULL);
+		} else {
+			// TODO handle arrays if needed
+			mv.visitLdcInsn(value.toString());
+		}
+	}
+
+	private void initializeValidators(MethodVisitor mv) {
+		for (CustomValidatorInfo info : validators) {
+			String validatorType = info.getValidatorClass().getInternalName();
+			mv.visitTypeInsn(NEW, validatorType);
+			mv.visitInsn(DUP);
+			mv.visitMethodInsn(INVOKESPECIAL, validatorType, "<init>", "()V", false);
+			mv.visitInsn(DUP); // DUP for initialize call
+
+			// loader
+			mv.visitLdcInsn(Type.getObjectType(owner));
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Class", "getClassLoader", "()Ljava/lang/ClassLoader;", false);
+
+			// interfaces
+			mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.ICONST_1);
+			mv.visitTypeInsn(net.bytebuddy.jar.asm.Opcodes.ANEWARRAY, "java/lang/Class");
+			mv.visitInsn(DUP);
+			mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.ICONST_0);
+			mv.visitLdcInsn(Type.getObjectType(info.getAnnotationType().getInternalName()));
+			mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.AASTORE);
+
+			// InvocationHandler via LambdaMetafactory
+			mv.visitInvokeDynamicInsn("invoke", "()Ljava/lang/reflect/InvocationHandler;",
+					new Handle(H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "metafactory",
+							"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+							false),
+					Type.getType("(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;"),
+					new Handle(H_INVOKESTATIC, owner, info.getFieldName() + "$handler",
+							"(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;",
+							false),
+					Type.getType("(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;"));
+
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/reflect/Proxy", "newProxyInstance",
+					"(Ljava/lang/ClassLoader;[Ljava/lang/Class;Ljava/lang/reflect/InvocationHandler;)Ljava/lang/Object;",
+					false);
+			mv.visitTypeInsn(net.bytebuddy.jar.asm.Opcodes.CHECKCAST, info.getAnnotationType().getInternalName());
+
+			// call initialize
+			mv.visitMethodInsn(INVOKEVIRTUAL, validatorType, "initialize", "(Ljava/lang/annotation/Annotation;)V",
+					false);
+
+			// store in field
+			mv.visitFieldInsn(PUTSTATIC, owner, info.getFieldName(), "L" + validatorType + ";");
+		}
+	}
+
+}

--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotationValidatorClassVisitor.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotationValidatorClassVisitor.java
@@ -135,6 +135,89 @@ public class CustomAnnotationValidatorClassVisitor extends ClassVisitor {
 		} else if (value instanceof net.bytebuddy.description.type.TypeDescription) {
 			mv.visitLdcInsn(
 					Type.getObjectType(((net.bytebuddy.description.type.TypeDescription) value).getInternalName()));
+		} else if (value instanceof net.bytebuddy.description.type.TypeDescription[]) {
+			net.bytebuddy.description.type.TypeDescription[] array = (net.bytebuddy.description.type.TypeDescription[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitTypeInsn(net.bytebuddy.jar.asm.Opcodes.ANEWARRAY, "java/lang/Class");
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(Type.getObjectType(array[i].getInternalName()));
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.AASTORE);
+			}
+		} else if (value instanceof net.bytebuddy.description.enumeration.EnumerationDescription[]) {
+			net.bytebuddy.description.enumeration.EnumerationDescription[] array = (net.bytebuddy.description.enumeration.EnumerationDescription[]) value;
+			String enumInternalName = array.length > 0 ? array[0].getEnumerationType().getInternalName() : "java/lang/Enum";
+			mv.visitLdcInsn(array.length);
+			mv.visitTypeInsn(net.bytebuddy.jar.asm.Opcodes.ANEWARRAY, enumInternalName);
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitFieldInsn(net.bytebuddy.jar.asm.Opcodes.GETSTATIC,
+						array[i].getEnumerationType().getInternalName(), array[i].getValue(),
+						array[i].getEnumerationType().getDescriptor());
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.AASTORE);
+			}
+		} else if (value instanceof String[]) {
+			String[] array = (String[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitTypeInsn(net.bytebuddy.jar.asm.Opcodes.ANEWARRAY, "java/lang/String");
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(array[i]);
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.AASTORE);
+			}
+		} else if (value instanceof int[]) {
+			int[] array = (int[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitIntInsn(net.bytebuddy.jar.asm.Opcodes.NEWARRAY, net.bytebuddy.jar.asm.Opcodes.T_INT);
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(array[i]);
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.IASTORE);
+			}
+		} else if (value instanceof long[]) {
+			long[] array = (long[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitIntInsn(net.bytebuddy.jar.asm.Opcodes.NEWARRAY, net.bytebuddy.jar.asm.Opcodes.T_LONG);
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(array[i]);
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.LASTORE);
+			}
+		} else if (value instanceof boolean[]) {
+			boolean[] array = (boolean[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitIntInsn(net.bytebuddy.jar.asm.Opcodes.NEWARRAY, net.bytebuddy.jar.asm.Opcodes.T_BOOLEAN);
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(array[i] ? 1 : 0);
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.BASTORE);
+			}
+		} else if (value instanceof double[]) {
+			double[] array = (double[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitIntInsn(net.bytebuddy.jar.asm.Opcodes.NEWARRAY, net.bytebuddy.jar.asm.Opcodes.T_DOUBLE);
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(array[i]);
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.DASTORE);
+			}
+		} else if (value instanceof float[]) {
+			float[] array = (float[]) value;
+			mv.visitLdcInsn(array.length);
+			mv.visitIntInsn(net.bytebuddy.jar.asm.Opcodes.NEWARRAY, net.bytebuddy.jar.asm.Opcodes.T_FLOAT);
+			for (int i = 0; i < array.length; i++) {
+				mv.visitInsn(DUP);
+				mv.visitLdcInsn(i);
+				mv.visitLdcInsn(array[i]);
+				mv.visitInsn(net.bytebuddy.jar.asm.Opcodes.FASTORE);
+			}
 		} else if (value == null) {
 			mv.visitInsn(ACONST_NULL);
 		} else {

--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotations.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomAnnotations.java
@@ -34,6 +34,7 @@ import static net.bytebuddy.jar.asm.Type.getMethodDescriptor;
 import static net.bytebuddy.jar.asm.Type.getObjectType;
 import static net.bytebuddy.jar.asm.Type.getType;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import java.util.Arrays;
 import java.util.function.Function;
@@ -59,7 +60,13 @@ import net.bytebuddy.jar.asm.Type;
 @NoArgsConstructor(access = PRIVATE)
 public final class CustomAnnotations {
 
-	public static void addCustomAnnotations(MethodVisitor mv, Parameter parameter, TypeDescription annotation) {
+	public static void addCustomAnnotations(MethodVisitor mv, Parameter parameter, TypeDescription annotation,
+			String ownerInternalName) {
+		addCustomAnnotations(mv, parameter, annotation, ownerInternalName, null);
+	}
+
+	public static void addCustomAnnotations(MethodVisitor mv, Parameter parameter, TypeDescription annotation,
+			String ownerInternalName, Function<CustomValidatorInfo, String> fieldNameResolver) {
 		var contraint = annotation.getDeclaredAnnotations().ofType(Constraint.class);
 		if (contraint == null) {
 			return;
@@ -75,27 +82,71 @@ public final class CustomAnnotations {
 
 		for (TypeDescription validatorClass : validatorClasses) {
 			String validatorType = validatorClass.getInternalName();
-			mv.visitTypeInsn(NEW, validatorType);
-			mv.visitInsn(DUP);
-			mv.visitMethodInsn(INVOKESPECIAL, validatorType, "<init>", "()V", false);
-			mv.visitVarInsn(ALOAD, parameter.index());
-			mv.visitInsn(ACONST_NULL);
-			String descriptor = getMethodDescriptor(BOOLEAN_TYPE,
-					getObjectType(typeThatGetsValidated(validatorClass).getInternalName()),
-					getType(ConstraintValidatorContext.class));
-			mv.visitMethodInsn(INVOKEVIRTUAL, validatorType, "isValid", descriptor, false);
-			Label label0 = new Label();
-			mv.visitJumpInsn(IFNE, label0);
-			mv.visitTypeInsn(NEW, "java/lang/IllegalArgumentException");
-			mv.visitInsn(DUP);
-			var message = parameter.annotationValue(getObjectType(annotation.getInternalName()), "message");
-			mv.visitLdcInsn(getMessage(parameter, annotation, message));
-			injectFormatMessage(mv, parameter);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/IllegalArgumentException", "<init>", "(Ljava/lang/String;)V",
-					false);
-			mv.visitInsn(ATHROW);
-			mv.visitLabel(label0);
+
+			String fieldName = null;
+			if (fieldNameResolver != null && overridesInitialize(validatorClass, annotation)) {
+				CustomValidatorInfo info = new CustomValidatorInfo(validatorClass, annotation,
+						annotationValues(parameter, annotation), null);
+				fieldName = fieldNameResolver.apply(info);
+			}
+
+			if (fieldName != null) {
+				if (mv != null) {
+					mv.visitFieldInsn(net.bytebuddy.jar.asm.Opcodes.GETSTATIC, ownerInternalName, fieldName,
+							"L" + validatorType + ";");
+				}
+			} else {
+				if (mv != null) {
+					mv.visitTypeInsn(NEW, validatorType);
+					mv.visitInsn(DUP);
+					mv.visitMethodInsn(INVOKESPECIAL, validatorType, "<init>", "()V", false);
+				}
+			}
+
+			if (mv != null) {
+				mv.visitVarInsn(ALOAD, parameter.index());
+				mv.visitInsn(ACONST_NULL);
+				String descriptor = getMethodDescriptor(BOOLEAN_TYPE,
+						getObjectType(typeThatGetsValidated(validatorClass).getInternalName()),
+						getType(ConstraintValidatorContext.class));
+				mv.visitMethodInsn(INVOKEVIRTUAL, validatorType, "isValid", descriptor, false);
+				Label label0 = new Label();
+				mv.visitJumpInsn(IFNE, label0);
+				mv.visitTypeInsn(NEW, "java/lang/IllegalArgumentException");
+				mv.visitInsn(DUP);
+				var message = parameter.annotationValue(getObjectType(annotation.getInternalName()), "message");
+				mv.visitLdcInsn(getMessage(parameter, annotation, message));
+				injectFormatMessage(mv, parameter);
+				mv.visitMethodInsn(INVOKESPECIAL, "java/lang/IllegalArgumentException", "<init>", "(Ljava/lang/String;)V",
+						false);
+				mv.visitInsn(ATHROW);
+				mv.visitLabel(label0);
+			}
 		}
+	}
+
+	private static java.util.Map<String, Object> annotationValues(Parameter parameter, TypeDescription annotation) {
+		java.util.Map<String, Object> values = new java.util.HashMap<>();
+		for (InDefinedShape method : annotation.getDeclaredMethods()) {
+			String name = method.getName();
+			Object value = parameter.annotationValue(getObjectType(annotation.getInternalName()), name);
+			if (value == null) {
+				value = method.getDefaultValue().resolve();
+			}
+			values.put(name, value);
+		}
+		return values;
+	}
+
+	public static boolean overridesInitialize(TypeDescription validatorClass, TypeDescription annotationType) {
+		TypeDescription current = validatorClass;
+		while (current != null && !current.represents(Object.class)) {
+			if (!current.getDeclaredMethods().filter(named("initialize").and(takesArguments(annotationType))).isEmpty()) {
+				return !current.represents(ConstraintValidator.class);
+			}
+			current = current.getSuperClass() == null ? null : current.getSuperClass().asErasure();
+		}
+		return false;
 	}
 
 	private static final Pattern annoMethodPattern = Pattern.compile("anno\\.(\\w+)\\(\\)");

--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomValidatorInfo.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/CustomValidatorInfo.java
@@ -1,0 +1,15 @@
+package com.github.pfichtner.vaadoo;
+
+import java.util.Map;
+import net.bytebuddy.description.type.TypeDescription;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(exclude = "fieldName")
+public class CustomValidatorInfo {
+	TypeDescription validatorClass;
+	TypeDescription annotationType;
+	Map<String, Object> annotationValues;
+	String fieldName;
+}

--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/org/jmolecules/bytebuddy/VaadooImplementor.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/org/jmolecules/bytebuddy/VaadooImplementor.java
@@ -59,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -123,7 +124,7 @@ class VaadooImplementor {
 				.map(MethodDescription.InDefinedShape::getName).collect(toList()));
 		Set<String> allGeneratedValidateMethodNames = new HashSet<>();
 
-		Map<CustomValidatorInfo, String> customValidatorFields = new HashMap<>();
+		Map<CustomValidatorInfo, String> customValidatorFields = new LinkedHashMap<>();
 		AtomicInteger validatorCounter = new AtomicInteger();
 		Function<CustomValidatorInfo, String> fieldNameResolver = info -> {
 			for (Map.Entry<CustomValidatorInfo, String> entry : customValidatorFields.entrySet()) {

--- a/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/org/jmolecules/bytebuddy/VaadooImplementor.java
+++ b/vaadoo-bytebuddy/src/main/java/com/github/pfichtner/vaadoo/org/jmolecules/bytebuddy/VaadooImplementor.java
@@ -61,12 +61,17 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.github.pfichtner.vaadoo.ConstructorAnnotationRemover;
+import com.github.pfichtner.vaadoo.CustomAnnotationValidatorClassVisitor;
+import com.github.pfichtner.vaadoo.CustomAnnotations;
+import com.github.pfichtner.vaadoo.CustomValidatorInfo;
 import com.github.pfichtner.vaadoo.Jsr380Annos;
 import com.github.pfichtner.vaadoo.Jsr380Annos.ConfigEntry;
 import com.github.pfichtner.vaadoo.Parameters;
@@ -118,6 +123,23 @@ class VaadooImplementor {
 				.map(MethodDescription.InDefinedShape::getName).collect(toList()));
 		Set<String> allGeneratedValidateMethodNames = new HashSet<>();
 
+		Map<CustomValidatorInfo, String> customValidatorFields = new HashMap<>();
+		AtomicInteger validatorCounter = new AtomicInteger();
+		Function<CustomValidatorInfo, String> fieldNameResolver = info -> {
+			for (Map.Entry<CustomValidatorInfo, String> entry : customValidatorFields.entrySet()) {
+				CustomValidatorInfo existing = entry.getKey();
+				if (existing.getValidatorClass().equals(info.getValidatorClass())
+						&& existing.getAnnotationType().equals(info.getAnnotationType())
+						&& valuesEqual(existing.getAnnotationValues(), info.getAnnotationValues())) {
+					return entry.getValue();
+				}
+			}
+			String name = "_$vaadoo_validator_" + validatorCounter.getAndIncrement();
+			customValidatorFields.put(new CustomValidatorInfo(info.getValidatorClass(), info.getAnnotationType(),
+					info.getAnnotationValues(), name), name);
+			return name;
+		};
+
 		for (InDefinedShape definedShape : typeDescription.getDeclaredMethods()) {
 			if (definedShape.isConstructor()) {
 				Parameters parameters = Parameters.of(definedShape.getParameters());
@@ -131,7 +153,9 @@ class VaadooImplementor {
 					String validateParamMethodName = nonExistingMethodName(usedMethodNames,
 							VALIDATE_METHOD_BASE_NAME + "_" + parameter.name());
 					StaticValidateAppender parameterAppender = new StaticValidateAppender(validateParamMethodName,
-							parameter, configuration);
+							parameter, configuration, fieldNameResolver, typeDescription.getInternalName());
+
+					parameterAppender.triggerEagerResolution();
 
 					if (parameterAppender.hasInjections()) {
 						usedMethodNames.add(validateParamMethodName);
@@ -163,6 +187,11 @@ class VaadooImplementor {
 		}
 
 		if (!allGeneratedValidateMethodNames.isEmpty()) {
+			if (!customValidatorFields.isEmpty()) {
+				type = type.mapBuilder(t -> wrap(t,
+						cv -> new CustomAnnotationValidatorClassVisitor(cv, customValidatorFields.keySet())));
+			}
+
 			if (configuration.regexOptimizationEnabled()) {
 				type = type.mapBuilder(
 						t -> wrap(t, cv -> new PatternRewriteClassVisitor(cv, allGeneratedValidateMethodNames)));
@@ -174,6 +203,20 @@ class VaadooImplementor {
 		}
 
 		return type;
+	}
+
+	private static boolean valuesEqual(Map<String, Object> v1, Map<String, Object> v2) {
+		if (v1.size() != v2.size()) {
+			return false;
+		}
+		for (Map.Entry<String, Object> entry : v1.entrySet()) {
+			Object val1 = entry.getValue();
+			Object val2 = v2.get(entry.getKey());
+			if (!Objects.deepEquals(val1, val2)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private Builder<?> wrap(Builder<?> builder, Function<ClassVisitor, ClassVisitor> classVisitorProvider) {
@@ -233,6 +276,16 @@ class VaadooImplementor {
 
 	private static class StaticValidateAppender implements ByteCodeAppender {
 
+		public void triggerEagerResolution() {
+			for (InjectionTask task : injectionTasks) {
+				if (task instanceof CustomInjectionTask) {
+					CustomInjectionTask customTask = (CustomInjectionTask) task;
+					CustomAnnotations.addCustomAnnotations(null, customTask.parameter, customTask.annotation,
+							customTask.ownerInternalName, customTask.fieldNameResolver);
+				}
+			}
+		}
+
 		private interface InjectionTask {
 			void apply(ValidationCodeInjector injector, MethodVisitor mv, int argsSize);
 		}
@@ -260,10 +313,12 @@ class VaadooImplementor {
 		private static class CustomInjectionTask implements InjectionTask {
 			Parameter parameter;
 			TypeDescription annotation;
+			Function<CustomValidatorInfo, String> fieldNameResolver;
+			String ownerInternalName;
 
 			@Override
 			public void apply(ValidationCodeInjector __, MethodVisitor mv, int argsSize) {
-				addCustomAnnotations(mv, parameter, annotation);
+				addCustomAnnotations(mv, parameter, annotation, ownerInternalName, fieldNameResolver);
 			}
 		}
 
@@ -276,12 +331,17 @@ class VaadooImplementor {
 		private final String methodDescriptor;
 		private final List<InjectionTask> injectionTasks;
 		private final List<TypeDescription> jsr380RepeatableAnnotationContainers;
+		private final Function<CustomValidatorInfo, String> fieldNameResolver;
+		private final String ownerInternalName;
 
 		public StaticValidateAppender(String validateMethodName, Parameter parameter,
-				VaadooConfiguration configuration) {
+				VaadooConfiguration configuration, Function<CustomValidatorInfo, String> fieldNameResolver,
+				String ownerInternalName) {
 			this.validateMethodName = validateMethodName;
 			this.parameter = new ParameterWithOffsetZero(parameter);
 			this.configuration = configuration;
+			this.fieldNameResolver = fieldNameResolver;
+			this.ownerInternalName = ownerInternalName;
 			this.preComputedPatternFlags = computePatternFlagsDuringBuild(this.parameter);
 			this.fragmentMixinsCodeFragmentMethods = configuration.codeFragmentMixins().stream()
 					.map(m -> fragmentMethods(m)).flatMap(List::stream).collect(toList());
@@ -400,7 +460,7 @@ class VaadooImplementor {
 		private Stream<InjectionTask> custom(Parameter parameter, TypeDescription annotation) {
 			return configuration.customAnnotationsEnabled() && isStandardJr380Anno(annotation) //
 					? empty()
-					: Stream.of(CustomInjectionTask.of(parameter, annotation));
+					: Stream.of(CustomInjectionTask.of(parameter, annotation, fieldNameResolver, ownerInternalName));
 		}
 
 		public boolean hasInjections() {

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/ConstraintValidatorInitializeTest.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/ConstraintValidatorInitializeTest.java
@@ -17,12 +17,12 @@ class ConstraintValidatorInitializeTest {
 		var constructor = transformed.getDeclaredConstructor(Integer.class);
 
 		// Passes: 10 >= 10
-		assertThatNoException().isThrownBy(() -> constructor.newInstance(Integer.valueOf(10)));
+		assertThatNoException().isThrownBy(() -> constructor.newInstance(10));
 
-		// Fails: 5 < 10
-		// If initialize is NOT called, threshold is 0, so 5 >= 0 would PASS.
+		// Fails: 9 < 10
+		// If initialize is NOT called, threshold is 0, so 9 >= 0 would PASS.
 		// So this test SHOULD FAIL with current implementation.
-		assertThatThrownBy(() -> constructor.newInstance(Integer.valueOf(5)))
+		assertThatThrownBy(() -> constructor.newInstance(9))
 				.hasCauseInstanceOf(IllegalArgumentException.class)
 				.hasRootCauseMessage("value too small");
 	}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/ConstraintValidatorInitializeTest.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/ConstraintValidatorInitializeTest.java
@@ -1,0 +1,30 @@
+package com.github.pfichtner.vaadoo;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.MinExample;
+
+class ConstraintValidatorInitializeTest {
+
+	private final Transformer transformer = new Transformer();
+
+	@Test
+	void initializeMustBeCalled() throws Exception {
+		var transformed = transformer.transform(MinExample.class);
+		var constructor = transformed.getDeclaredConstructor(Integer.class);
+
+		// Passes: 10 >= 10
+		assertThatNoException().isThrownBy(() -> constructor.newInstance(Integer.valueOf(10)));
+
+		// Fails: 5 < 10
+		// If initialize is NOT called, threshold is 0, so 5 >= 0 would PASS.
+		// So this test SHOULD FAIL with current implementation.
+		assertThatThrownBy(() -> constructor.newInstance(Integer.valueOf(5)))
+				.hasCauseInstanceOf(IllegalArgumentException.class)
+				.hasRootCauseMessage("value too small");
+	}
+
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pfichtner.vaadoo;
+
+import static com.github.pfichtner.vaadoo.org.jmolecules.bytebuddy.config.VaadooConfigurationSupplier.VAADOO_CONFIG;
+import static java.lang.String.format;
+import static java.lang.System.lineSeparator;
+import static java.nio.file.Files.walk;
+import static java.util.Comparator.reverseOrder;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static net.jqwik.api.ShrinkingMode.OFF;
+import static org.approvaltests.Approvals.settings;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+import org.approvaltests.ApprovalSettings;
+import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
+
+import com.github.pfichtner.vaadoo.TestClassBuilder.AnnotationDefinition;
+import com.github.pfichtner.vaadoo.TestClassBuilder.DefaultParameterDefinition;
+import com.github.pfichtner.vaadoo.TestClassBuilder.ParameterDefinition;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+class CustomValidatorInitializePBTest {
+
+	static final Transformer transformer = new Transformer();
+
+	@Provide
+	Arbitrary<List<ParameterDefinition>> constructorParameters() {
+		return parameterConfigGen().list().ofMinSize(1).ofMaxSize(3);
+	}
+
+	Arbitrary<ParameterDefinition> parameterConfigGen() {
+		return Arbitraries.oneOf(
+				Arbitraries.integers().between(0, 100).map(min -> DefaultParameterDefinition.of(Integer.class,
+						AnnotationDefinition.of(MinReproduction.class, Map.of("min", min)))),
+				Arbitraries.strings().alpha().numeric().ofLength(5).map(s -> DefaultParameterDefinition.of(String.class,
+						AnnotationDefinition.of(ComplexReproduction.class, Map.of("stringValue", s, "intValue", 42,
+								"boolValue", true, "enumValue", TimeUnit.DAYS, "classValue", String.class)))));
+	}
+
+	private static final String FIXED_SEED = "42";
+
+	@Property(seed = FIXED_SEED, shrinking = OFF, tries = 5)
+	void customValidatorsWithInitialize(@ForAll("constructorParameters") List<ParameterDefinition> params)
+			throws Exception {
+		var projectRoot = configure(keepJsr380Annotations());
+		var approver = new Approver(new Transformer().projectRoot(projectRoot));
+		ApprovalSettings settings = settings();
+		settings.allowMultipleVerifyCallsForThisClass();
+		settings.allowMultipleVerifyCallsForThisMethod();
+		withProjectRoot(projectRoot, () -> approver.approveTransformed("Custom validators with initialize", params));
+	}
+
+	private static void withProjectRoot(File projectRoot, ThrowingRunnable runnable) throws Exception {
+		try {
+			runnable.run();
+		} finally {
+			try (var paths = walk(projectRoot.toPath())) {
+				paths.sorted(reverseOrder()).map(Path::toFile).forEach(File::delete);
+			}
+		}
+	}
+
+	private static Entry<String, Object> keepJsr380Annotations() {
+		return Map.entry("vaadoo.removeJsr380Annotations", false);
+	}
+
+	@SafeVarargs
+	private static File configure(Entry<String, Object>... entries) throws IOException {
+		File projectRoot = Files.createTempDirectory("project-root").toFile();
+		new File(projectRoot, "target/classes").mkdirs();
+		writeTo(new File(projectRoot, "pom.xml"), "");
+		writeTo(new File(projectRoot, VAADOO_CONFIG), Map.ofEntries(entries));
+		return projectRoot;
+	}
+
+	private static void writeTo(File file, Map<String, Object> data) throws IOException {
+		writeTo(file, content(data));
+	}
+
+	private static String content(Map<String, Object> data) {
+		return data.entrySet().stream() //
+				.map(e -> format("%s=%s", e.getKey(), e.getValue())) //
+				.collect(joining(lineSeparator()));
+	}
+
+	private static void writeTo(File file, String text) throws IOException {
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write(text);
+		}
+	}
+
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/TestClassBuilder.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/TestClassBuilder.java
@@ -400,6 +400,27 @@ public class TestClassBuilder implements Buildable<Unloaded<?>> {
 				builder = builder.define("regexp", getAnnotationValue(annotationDefinition, "regexp", ""));
 				Pattern.Flag[] flags = getAnnotationValue(annotationDefinition, "flags", new Pattern.Flag[0]);
 				builder = builder.defineEnumerationArray("flags", Pattern.Flag.class, flags);
+			} else {
+				for (Map.Entry<String, Object> entry : annotationDefinition.values().entrySet()) {
+					Object value = entry.getValue();
+					if (value instanceof Enum) {
+						builder = builder.define(entry.getKey(), (Enum<?>) value);
+					} else if (value instanceof Class) {
+						builder = builder.define(entry.getKey(), TypeDescription.ForLoadedType.of((Class<?>) value));
+					} else if (value instanceof String) {
+						builder = builder.define(entry.getKey(), (String) value);
+					} else if (value instanceof Integer) {
+						builder = builder.define(entry.getKey(), (Integer) value);
+					} else if (value instanceof Long) {
+						builder = builder.define(entry.getKey(), (Long) value);
+					} else if (value instanceof Double) {
+						builder = builder.define(entry.getKey(), (Double) value);
+					} else if (value instanceof Float) {
+						builder = builder.define(entry.getKey(), (Float) value);
+					} else if (value instanceof Boolean) {
+						builder = builder.define(entry.getKey(), (Boolean) value);
+					}
+				}
 			}
 			return builder.build();
 		} catch (Exception e) {

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/ComplexReproduction.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/ComplexReproduction.java
@@ -1,0 +1,31 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = ComplexValidator.class)
+public @interface ComplexReproduction {
+	String message() default "complex failure";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+	
+	String stringValue() default "";
+	int intValue() default 0;
+	boolean boolValue() default false;
+	long longValue() default 0L;
+	double doubleValue() default 0.0;
+	float floatValue() default 0.0f;
+	java.util.concurrent.TimeUnit enumValue() default java.util.concurrent.TimeUnit.SECONDS;
+	Class<?> classValue() default Object.class;
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/ComplexValidator.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/ComplexValidator.java
@@ -1,0 +1,18 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ComplexValidator implements ConstraintValidator<ComplexReproduction, Object> {
+	private ComplexReproduction annotation;
+
+	@Override
+	public void initialize(ComplexReproduction annotation) {
+		this.annotation = annotation;
+	}
+
+	@Override
+	public boolean isValid(Object value, ConstraintValidatorContext context) {
+		return annotation != null;
+	}
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinExample.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinExample.java
@@ -4,9 +4,12 @@ import org.jmolecules.ddd.annotation.ValueObject;
 
 @ValueObject
 public class MinExample {
+
+	@SuppressWarnings("unused")
 	private final Integer value;
 
 	public MinExample(@MinReproduction(min = 10) Integer value) {
 		this.value = value;
 	}
+
 }

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinExample.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinExample.java
@@ -1,0 +1,12 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import org.jmolecules.ddd.annotation.ValueObject;
+
+@ValueObject
+public class MinExample {
+	private final Integer value;
+
+	public MinExample(@MinReproduction(min = 10) Integer value) {
+		this.value = value;
+	}
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinReproduction.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinReproduction.java
@@ -19,5 +19,5 @@ public @interface MinReproduction {
 	String message() default "value too small";
 	Class<?>[] groups() default {};
 	Class<? extends Payload>[] payload() default {};
-	int min() default 0;
+	int min();
 }

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinReproduction.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinReproduction.java
@@ -1,0 +1,23 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = MinValidator.class)
+public @interface MinReproduction {
+	String message() default "value too small";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+	int min() default 0;
+}

--- a/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinValidator.java
+++ b/vaadoo-bytebuddy/src/test/java/com/github/pfichtner/vaadoo/testclasses/custom/MinValidator.java
@@ -1,0 +1,18 @@
+package com.github.pfichtner.vaadoo.testclasses.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class MinValidator implements ConstraintValidator<MinReproduction, Integer> {
+	private int min;
+
+	@Override
+	public void initialize(MinReproduction annotation) {
+		this.min = annotation.min();
+	}
+
+	@Override
+	public boolean isValid(Integer value, ConstraintValidatorContext context) {
+		return value != null && value >= min;
+	}
+}

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1165384895.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1165384895.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=AAAAA})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=26})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=sBZUy})])
+
+
+Source:
+Analysing type com.example.Generated_1165384895
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1165384895
+implements ValueObject {
+    public Generated_1165384895(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1165384895
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1165384895;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1165384895
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_1165384895(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+        Generated_1165384895.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_1165384895(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_1165384895.validate_string(string);
+        Generated_1165384895.validate_integer(n);
+        Generated_1165384895.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1165384895.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "sBZUy";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1165384895.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 26;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1165384895.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "AAAAA";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1444080871.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1444080871.approved.txt
@@ -1,0 +1,106 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=jVt1V})])
+
+
+Source:
+Analysing type com.example.Generated_1444080871
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1444080871
+implements ValueObject {
+    public Generated_1444080871(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="jVt1V") String string) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1444080871
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1444080871;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1444080871
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+
+    public Generated_1444080871(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="jVt1V") String string) {
+        Generated_1444080871.validate(string);
+        this(string, null);
+    }
+
+    private /* synthetic */ Generated_1444080871(String string, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_0.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string) {
+        Generated_1444080871.validate_string(string);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1444080871.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "jVt1V";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1518903861.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1518903861.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=AAAAA})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=26})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=sBZUy})])
+
+
+Source:
+Analysing type com.example.Generated_1518903861
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1518903861
+implements ValueObject {
+    public Generated_1518903861(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1518903861
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1518903861;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1518903861
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_1518903861(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+        Generated_1518903861.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_1518903861(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_1518903861.validate_string(string);
+        Generated_1518903861.validate_integer(n);
+        Generated_1518903861.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1518903861.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "sBZUy";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1518903861.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 26;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1518903861.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "AAAAA";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1615322571.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1615322571.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=AAAAA})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=26})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=sBZUy})])
+
+
+Source:
+Analysing type com.example.Generated_1615322571
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1615322571
+implements ValueObject {
+    public Generated_1615322571(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1615322571
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1615322571;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1615322571
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_1615322571(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+        Generated_1615322571.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_1615322571(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_1615322571.validate_string(string);
+        Generated_1615322571.validate_integer(n);
+        Generated_1615322571.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1615322571.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "sBZUy";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1615322571.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 26;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1615322571.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "AAAAA";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1766960183.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1766960183.approved.txt
@@ -1,0 +1,321 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=74})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=99})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=23})])
+
+
+Source:
+Analysing type com.example.Generated_1766960183
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1766960183
+implements ValueObject {
+    public Generated_1766960183(@MinReproduction(groups={}, message="value too small", min=74, payload={}) Integer n, @MinReproduction(groups={}, message="value too small", min=99, payload={}) Integer n2, @MinReproduction(groups={}, message="value too small", min=23, payload={}) Integer n3) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1766960183
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1766960183;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1766960183
+implements ValueObject {
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_2;
+
+    public Generated_1766960183(@MinReproduction(groups={}, message="value too small", min=74, payload={}) Integer n, @MinReproduction(groups={}, message="value too small", min=99, payload={}) Integer n2, @MinReproduction(groups={}, message="value too small", min=23, payload={}) Integer n3) {
+        Generated_1766960183.validate(n, n2, n3);
+        this(n, n2, n3, null);
+    }
+
+    private /* synthetic */ Generated_1766960183(Integer n, Integer n2, Integer n3, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer2(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer1(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_integer(Integer n) {
+        if (!_$vaadoo_validator_2.isValid(n, null)) {
+            throw new IllegalArgumentException(String.format("value too small", n));
+        }
+    }
+
+    private static void validate(Integer n, Integer n2, Integer n3) {
+        Generated_1766960183.validate_integer(n);
+        Generated_1766960183.validate_integer1(n2);
+        Generated_1766960183.validate_integer2(n3);
+    }
+
+    static {
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1766960183.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 23;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = minValidator;
+        MinValidator minValidator2 = new MinValidator();
+        minValidator2.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1766960183.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 99;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator2;
+        MinValidator minValidator3 = new MinValidator();
+        minValidator3.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1766960183.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 74;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = minValidator3;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.182470719.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.182470719.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=AAAAA})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=26})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=sBZUy})])
+
+
+Source:
+Analysing type com.example.Generated_182470719
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_182470719
+implements ValueObject {
+    public Generated_182470719(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_182470719
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_182470719;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_182470719
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_182470719(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+        Generated_182470719.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_182470719(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_182470719.validate_string(string);
+        Generated_182470719.validate_integer(n);
+        Generated_182470719.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_182470719.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "sBZUy";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_182470719.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 26;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_182470719.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "AAAAA";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1882928856.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1882928856.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=SvG7R})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=99})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=7czW7})])
+
+
+Source:
+Analysing type com.example.Generated_1882928856
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1882928856
+implements ValueObject {
+    public Generated_1882928856(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="SvG7R") String string, @MinReproduction(groups={}, message="value too small", min=99, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="7czW7") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1882928856
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1882928856;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1882928856
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_1882928856(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="SvG7R") String string, @MinReproduction(groups={}, message="value too small", min=99, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="7czW7") String string2) {
+        Generated_1882928856.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_1882928856(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_1882928856.validate_string(string);
+        Generated_1882928856.validate_integer(n);
+        Generated_1882928856.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1882928856.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "7czW7";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1882928856.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 99;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1882928856.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "SvG7R";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1901235830.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.1901235830.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=0})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=QAqG8})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=lZy0l})])
+
+
+Source:
+Analysing type com.example.Generated_1901235830
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1901235830
+implements ValueObject {
+    public Generated_1901235830(@MinReproduction(groups={}, message="value too small", min=0, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="QAqG8") String string, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="lZy0l") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_1901235830
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_1901235830;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_1901235830
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_2;
+
+    public Generated_1901235830(@MinReproduction(groups={}, message="value too small", min=0, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="QAqG8") String string, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="lZy0l") String string2) {
+        Generated_1901235830.validate(n, string, string2);
+        this(n, string, string2, null);
+    }
+
+    private /* synthetic */ Generated_1901235830(Integer n, String string, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_integer(Integer n) {
+        if (!_$vaadoo_validator_2.isValid(n, null)) {
+            throw new IllegalArgumentException(String.format("value too small", n));
+        }
+    }
+
+    private static void validate(Integer n, String string, String string2) {
+        Generated_1901235830.validate_integer(n);
+        Generated_1901235830.validate_string(string);
+        Generated_1901235830.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1901235830.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "lZy0l";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_1901235830.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "QAqG8";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = complexValidator2;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_1901235830.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 0;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = minValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.194125877.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.194125877.approved.txt
@@ -1,0 +1,83 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=0})])
+
+
+Source:
+Analysing type com.example.Generated_194125877
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_194125877
+implements ValueObject {
+    public Generated_194125877(@MinReproduction(groups={}, message="value too small", min=0, payload={}) Integer n) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_194125877
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_194125877;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_194125877
+implements ValueObject {
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_0;
+
+    public Generated_194125877(@MinReproduction(groups={}, message="value too small", min=0, payload={}) Integer n) {
+        Generated_194125877.validate(n);
+        this(n, null);
+    }
+
+    private /* synthetic */ Generated_194125877(Integer n, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    private static void validate_integer(Integer n) {
+        if (!_$vaadoo_validator_0.isValid(n, null)) {
+            throw new IllegalArgumentException(String.format("value too small", n));
+        }
+    }
+
+    private static void validate(Integer n) {
+        Generated_194125877.validate_integer(n);
+    }
+
+    static {
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_194125877.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 0;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = minValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.194125908.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.194125908.approved.txt
@@ -1,0 +1,83 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=1})])
+
+
+Source:
+Analysing type com.example.Generated_194125908
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_194125908
+implements ValueObject {
+    public Generated_194125908(@MinReproduction(groups={}, message="value too small", min=1, payload={}) Integer n) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_194125908
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_194125908;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_194125908
+implements ValueObject {
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_0;
+
+    public Generated_194125908(@MinReproduction(groups={}, message="value too small", min=1, payload={}) Integer n) {
+        Generated_194125908.validate(n);
+        this(n, null);
+    }
+
+    private /* synthetic */ Generated_194125908(Integer n, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    private static void validate_integer(Integer n) {
+        if (!_$vaadoo_validator_0.isValid(n, null)) {
+            throw new IllegalArgumentException(String.format("value too small", n));
+        }
+    }
+
+    private static void validate(Integer n) {
+        Generated_194125908.validate_integer(n);
+    }
+
+    static {
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_194125908.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 1;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = minValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.194125939.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.194125939.approved.txt
@@ -1,0 +1,83 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=2})])
+
+
+Source:
+Analysing type com.example.Generated_194125939
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_194125939
+implements ValueObject {
+    public Generated_194125939(@MinReproduction(groups={}, message="value too small", min=2, payload={}) Integer n) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_194125939
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_194125939;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_194125939
+implements ValueObject {
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_0;
+
+    public Generated_194125939(@MinReproduction(groups={}, message="value too small", min=2, payload={}) Integer n) {
+        Generated_194125939.validate(n);
+        this(n, null);
+    }
+
+    private /* synthetic */ Generated_194125939(Integer n, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    private static void validate_integer(Integer n) {
+        if (!_$vaadoo_validator_0.isValid(n, null)) {
+            throw new IllegalArgumentException(String.format("value too small", n));
+        }
+    }
+
+    private static void validate(Integer n) {
+        Generated_194125939.validate_integer(n);
+    }
+
+    static {
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_194125939.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 2;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = minValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.2021553981.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.2021553981.approved.txt
@@ -1,0 +1,106 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=jVt1V})])
+
+
+Source:
+Analysing type com.example.Generated_2021553981
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_2021553981
+implements ValueObject {
+    public Generated_2021553981(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="jVt1V") String string) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_2021553981
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_2021553981;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_2021553981
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+
+    public Generated_2021553981(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="jVt1V") String string) {
+        Generated_2021553981.validate(string);
+        this(string, null);
+    }
+
+    private /* synthetic */ Generated_2021553981(String string, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_0.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string) {
+        Generated_2021553981.validate_string(string);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_2021553981.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "jVt1V";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.2071618112.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.2071618112.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=0})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=QAqG8})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=lZy0l})])
+
+
+Source:
+Analysing type com.example.Generated_2071618112
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_2071618112
+implements ValueObject {
+    public Generated_2071618112(@MinReproduction(groups={}, message="value too small", min=0, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="QAqG8") String string, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="lZy0l") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_2071618112
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_2071618112;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_2071618112
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_2;
+
+    public Generated_2071618112(@MinReproduction(groups={}, message="value too small", min=0, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="QAqG8") String string, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="lZy0l") String string2) {
+        Generated_2071618112.validate(n, string, string2);
+        this(n, string, string2, null);
+    }
+
+    private /* synthetic */ Generated_2071618112(Integer n, String string, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_integer(Integer n) {
+        if (!_$vaadoo_validator_2.isValid(n, null)) {
+            throw new IllegalArgumentException(String.format("value too small", n));
+        }
+    }
+
+    private static void validate(Integer n, String string, String string2) {
+        Generated_2071618112.validate_integer(n);
+        Generated_2071618112.validate_string(string);
+        Generated_2071618112.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_2071618112.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "lZy0l";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_2071618112.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "QAqG8";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = complexValidator2;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_2071618112.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 0;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = minValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.391883839.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.391883839.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=AAAAA})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=26})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=sBZUy})])
+
+
+Source:
+Analysing type com.example.Generated_391883839
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_391883839
+implements ValueObject {
+    public Generated_391883839(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_391883839
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_391883839;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_391883839
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_391883839(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+        Generated_391883839.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_391883839(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_391883839.validate_string(string);
+        Generated_391883839.validate_integer(n);
+        Generated_391883839.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_391883839.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "sBZUy";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_391883839.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 26;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_391883839.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "AAAAA";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.524044879.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.524044879.approved.txt
@@ -1,0 +1,228 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=jSqSv})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=3})])
+
+
+Source:
+Analysing type com.example.Generated_524044879
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_524044879
+implements ValueObject {
+    public Generated_524044879(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="jSqSv") String string, @MinReproduction(groups={}, message="value too small", min=3, payload={}) Integer n) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_524044879
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_524044879;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_524044879
+implements ValueObject {
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_1;
+
+    public Generated_524044879(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="jSqSv") String string, @MinReproduction(groups={}, message="value too small", min=3, payload={}) Integer n) {
+        Generated_524044879.validate(string, n);
+        this(string, n, null);
+    }
+
+    private /* synthetic */ Generated_524044879(String string, Integer n, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_1.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n) {
+        Generated_524044879.validate_string(string);
+        Generated_524044879.validate_integer(n);
+    }
+
+    static {
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_524044879.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 3;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = minValidator;
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_524044879.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "jSqSv";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = complexValidator;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.908885238.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.908885238.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=SvG7R})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=99})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=7czW7})])
+
+
+Source:
+Analysing type com.example.Generated_908885238
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_908885238
+implements ValueObject {
+    public Generated_908885238(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="SvG7R") String string, @MinReproduction(groups={}, message="value too small", min=99, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="7czW7") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_908885238
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_908885238;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_908885238
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_908885238(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="SvG7R") String string, @MinReproduction(groups={}, message="value too small", min=99, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="7czW7") String string2) {
+        Generated_908885238.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_908885238(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_908885238.validate_string(string);
+        Generated_908885238.validate_integer(n);
+        Generated_908885238.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_908885238.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "7czW7";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_908885238.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 99;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_908885238.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "SvG7R";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+

--- a/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.939246645.approved.txt
+++ b/vaadoo-bytebuddy/src/test/resources/com/github/pfichtner/vaadoo/CustomValidatorInitializePBTest.customValidatorsWithInitialize.939246645.approved.txt
@@ -1,0 +1,368 @@
+Story:
+Custom validators with initialize
+
+params annotations
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=AAAAA})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.Integer, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction, values={min=26})])
+-: TestClassBuilder.DefaultParameterDefinition(typeDefinition=TestClassBuilder.TypeDefinition(type=class java.lang.String, genericType=null, genericTypeAnnotations=[]), annotations=[TestClassBuilder.AnnotationDefinition(annotation=interface com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction, values={boolValue=true, classValue=class java.lang.String, enumValue=DAYS, intValue=42, stringValue=sBZUy})])
+
+
+Source:
+Analysing type com.example.Generated_939246645
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_939246645
+implements ValueObject {
+    public Generated_939246645(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+    }
+}
+
+
+
+Transformed:
+Analysing type com.example.Generated_939246645
+/*
+ * Decompiled with CFR.
+ */
+package com.example;
+
+import com.example.Generated_939246645;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.ComplexValidator;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinReproduction;
+import com.github.pfichtner.vaadoo.testclasses.custom.MinValidator;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import org.jmolecules.ddd.types.ValueObject;
+
+public class Generated_939246645
+implements ValueObject {
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_0;
+    private static final /* synthetic */ MinValidator _$vaadoo_validator_1;
+    private static final /* synthetic */ ComplexValidator _$vaadoo_validator_2;
+
+    public Generated_939246645(@ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="AAAAA") String string, @MinReproduction(groups={}, message="value too small", min=26, payload={}) Integer n, @ComplexReproduction(boolValue=true, classValue=String.class, doubleValue=0.0, enumValue=TimeUnit.DAYS, floatValue=0.0f, groups={}, intValue=42, longValue=0L, message="complex failure", payload={}, stringValue="sBZUy") String string2) {
+        Generated_939246645.validate(string, n, string2);
+        this(string, n, string2, null);
+    }
+
+    private /* synthetic */ Generated_939246645(String string, Integer n, String string2, auxiliary.[AUX1_1 AUX1_1] {
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_string1(String var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    /*
+     * Exception decompiling
+     */
+    private static void validate_integer(Integer var0) {
+        /*
+         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
+         * 
+         * java.lang.IllegalStateException: Invisible function parameters on a non-constructor (or reads of uninitialised local variables).
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.assignSSAIdentifiers(Op02WithProcessedDataAndRefs.java:1631)
+         *     at org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRefs.discoverStorageLiveness(Op02WithProcessedDataAndRefs.java:1871)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:461)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:278)
+         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:201)
+         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
+         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:531)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1055)
+         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:942)
+         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:84)
+         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:78)
+         *     at com.github.pfichtner.vaadoo.Decompiler.decompile(Decompiler.java:62)
+         *     at com.github.pfichtner.vaadoo.Approver.decompile(Approver.java:81)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:64)
+         *     at com.github.pfichtner.vaadoo.Approver.approveTransformed(Approver.java:48)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.lambda$customValidatorsWithInitialize$0(CustomValidatorInitializePBTest.java:82)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.withProjectRoot(CustomValidatorInitializePBTest.java:87)
+         *     at com.github.pfichtner.vaadoo.CustomValidatorInitializePBTest.customValidatorsWithInitialize(CustomValidatorInitializePBTest.java:82)
+         *     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+         *     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+         *     at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
+         *     at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$1(CheckedPropertyFactory.java:84)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createRawFunction$2(CheckedPropertyFactory.java:91)
+         *     at net.jqwik.engine.properties.CheckedFunction.execute(CheckedFunction.java:17)
+         *     at net.jqwik.api.lifecycle.AroundTryHook.lambda$static$0(AroundTryHook.java:57)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.TryLifecycleMethodsHook.aroundTry(TryLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$2(HookSupport.java:48)
+         *     at net.jqwik.engine.hooks.lifecycle.BeforeTryMembersHook.aroundTry(BeforeTryMembersHook.java:69)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$3(HookSupport.java:53)
+         *     at net.jqwik.engine.execution.CheckedPropertyFactory.lambda$createTryExecutor$0(CheckedPropertyFactory.java:60)
+         *     at net.jqwik.engine.execution.lifecycle.AroundTryLifecycle.execute(AroundTryLifecycle.java:23)
+         *     at net.jqwik.engine.properties.GenericProperty.testPredicate(GenericProperty.java:166)
+         *     at net.jqwik.engine.properties.GenericProperty.check(GenericProperty.java:68)
+         *     at net.jqwik.engine.execution.CheckedProperty.check(CheckedProperty.java:67)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeProperty(PropertyMethodExecutor.java:90)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.executeMethod(PropertyMethodExecutor.java:69)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.lambda$execute$0(PropertyMethodExecutor.java:49)
+         *     at net.jqwik.api.lifecycle.AroundPropertyHook.lambda$static$0(AroundPropertyHook.java:46)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.api.lifecycle.PropertyExecutor.executeAndFinally(PropertyExecutor.java:39)
+         *     at net.jqwik.engine.hooks.lifecycle.PropertyLifecycleMethodsHook.aroundProperty(PropertyLifecycleMethodsHook.java:56)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.statistics.StatisticsHook.aroundProperty(StatisticsHook.java:37)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$0(HookSupport.java:26)
+         *     at net.jqwik.engine.hooks.lifecycle.AutoCloseableHook.aroundProperty(AutoCloseableHook.java:13)
+         *     at net.jqwik.engine.execution.lifecycle.HookSupport.lambda$wrap$1(HookSupport.java:31)
+         *     at net.jqwik.engine.execution.PropertyMethodExecutor.execute(PropertyMethodExecutor.java:47)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.executeTestMethod(PropertyTaskCreator.java:166)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$1(PropertyTaskCreator.java:51)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentDomainContext.runWithContext(CurrentDomainContext.java:30)
+         *     at net.jqwik.engine.execution.PropertyTaskCreator.lambda$createTask$2(PropertyTaskCreator.java:50)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.lambda$execute$0(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.lifecycle.CurrentTestDescriptor.runWithDescriptor(CurrentTestDescriptor.java:18)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionTask$1.execute(ExecutionTask.java:31)
+         *     at net.jqwik.engine.execution.pipeline.ExecutionPipeline.runToTermination(ExecutionPipeline.java:82)
+         *     at net.jqwik.engine.execution.JqwikExecutor.execute(JqwikExecutor.java:46)
+         *     at net.jqwik.engine.JqwikTestEngine.executeTests(JqwikTestEngine.java:70)
+         *     at net.jqwik.engine.JqwikTestEngine.execute(JqwikTestEngine.java:53)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+         *     at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+         *     at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
+         *     at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+         *     at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
+         *     at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithoutCancellationToken(LauncherAdapter.java:60)
+         *     at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:52)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
+         *     at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+         *     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+         */
+        throw new IllegalStateException("Decompilation failed");
+    }
+
+    private static void validate_string(String string) {
+        if (!_$vaadoo_validator_2.isValid((Object)string, null)) {
+            throw new IllegalArgumentException(String.format("complex failure", string));
+        }
+    }
+
+    private static void validate(String string, Integer n, String string2) {
+        Generated_939246645.validate_string(string);
+        Generated_939246645.validate_integer(n);
+        Generated_939246645.validate_string1(string2);
+    }
+
+    static {
+        ComplexValidator complexValidator = new ComplexValidator();
+        complexValidator.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_939246645.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "sBZUy";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_0 = complexValidator;
+        MinValidator minValidator = new MinValidator();
+        minValidator.initialize((Annotation)((MinReproduction)Proxy.newProxyInstance(Generated_939246645.class.getClassLoader(), new Class[]{MinReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("min")) {
+                return 26;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("message")) {
+                return "value too small";
+            }
+            return null;
+        })));
+        _$vaadoo_validator_1 = minValidator;
+        ComplexValidator complexValidator2 = new ComplexValidator();
+        complexValidator2.initialize((Annotation)((ComplexReproduction)Proxy.newProxyInstance(Generated_939246645.class.getClassLoader(), new Class[]{ComplexReproduction.class}, (object, method, objectArray) -> {
+            String string = method.getName();
+            if (string.equals("stringValue")) {
+                return "AAAAA";
+            }
+            if (string.equals("classValue")) {
+                return String.class;
+            }
+            if (string.equals("enumValue")) {
+                return TimeUnit.DAYS;
+            }
+            if (string.equals("payload")) {
+                return new Class[0];
+            }
+            if (string.equals("intValue")) {
+                return 42;
+            }
+            if (string.equals("floatValue")) {
+                return Float.valueOf(0.0f);
+            }
+            if (string.equals("groups")) {
+                return new Class[0];
+            }
+            if (string.equals("boolValue")) {
+                return true;
+            }
+            if (string.equals("doubleValue")) {
+                return 0.0;
+            }
+            if (string.equals("message")) {
+                return "complex failure";
+            }
+            if (string.equals("longValue")) {
+                return 0L;
+            }
+            return null;
+        })));
+        _$vaadoo_validator_2 = complexValidator2;
+    }
+}
+


### PR DESCRIPTION
This PR adds support for the ConstraintValidator#initialize lifecycle method in custom validators. This ensures that validators can correctly access annotation attributes (like min, max, or custom regex patterns) at runtime, fulfilling JSR 380 requirements while strictly adhering to the project's constraint of not creating additional class files.

## Problem
Previously, vaadoo only supported validators that didn't require initialization. For validators implementing initialize(A annotation), the method was never called. This led to uninitialized fields within the validator instances, resulting in incorrect validation logic (e.g., a MinValidator always using a default threshold of 0 instead of the value specified in the annotation).

## Solution: Static Validator Cache with Weaved Proxies
The implementation leverages a "self-contained" bytecode strategy that keeps the output classes 1:1 with the input classes:

 1. Static Fields: For each unique validator/annotation combination, a private static final field is weaved into the target class.
 2. Static Initialization (<clinit>): The class's static initializer is intercepted (or created) to perform
    the following once during class loading:
     * Instantiate the validator.
     * Create a dynamic proxy for the annotation type using java.lang.reflect.Proxy.
     * Implement the InvocationHandler via INVOKEDYNAMIC: To avoid creating a separate .class file for the handler, we use LambdaMetafactory to point to a private static $handler method weaved into the same class. This method returns the annotation values known at compile-time.
     * Call validator.initialize(proxy).
     * Store the initialized instance in the static field.
 3. Deduplication: A fieldNameResolver ensures that identical validators (same class, same annotation, same attributes) share the same static field across different parameters or constructors.
 4. Optimized Validation Site: CustomAnnotations now replaces the NEW/DUP/INVOKESPECIAL sequence with a GETSTATIC call for validators that require initialization.
### Key Changes
 - CustomAnnotationValidatorClassVisitor: A new ASM visitor that handles the weaving of static fields, handler methods, and the initialization logic in <clinit>.
 - VaadooImplementor: Updated to coordinate validator collection and integrate the new visitor into the ByteBuddy transformation chain.
 - CustomAnnotations: Enhanced to detect initialize overrides and resolve the appropriate injection strategy (new instance vs. cached instance).
 - CustomValidatorInfo: Metadata holder used for deduplication and field mapping.

## Verification
 - Reproduction Test: Added ConstraintValidatorInitializeTest which confirms the failure state (initialization not called) and verifies the fix.
 - Regression Testing: Validated that existing regex optimizations and standard JSR 380 validations remain unaffected.
 - Architectural Integrity: Confirmed via build that no extra .class files are generated; all logic is self-contained within the transformed classes.

Technical Details
 - Uses INVOKEDYNAMIC for InvocationHandler implementation to satisfy the "no extra classes" rule.
 - Handles various attribute types including Primitives, Strings, Enums, and Classes.
 - Implements deep equality for annotation values to ensure correct deduplication.